### PR TITLE
Watch covered files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@hmh/lit-element-tester",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
             }
         },
         "@babel/generator": {
-            "version": "7.1.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.5.tgz",
-            "integrity": "sha512-IO31r62xfMI+wBJVmgx0JR9ZOHty8HkoYpQAjRWUGG9vykBTlGHdArZ8zoFtpUu2gs17K7qTl/TtPpiSi6t+MA==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
+            "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
             "requires": {
-                "@babel/types": "^7.1.5",
+                "@babel/types": "^7.1.6",
                 "jsesc": "^2.5.1",
                 "lodash": "^4.17.10",
                 "source-map": "^0.5.0",
@@ -61,9 +61,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.1.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.5.tgz",
-            "integrity": "sha512-WXKf5K5HT6X0kKiCOezJZFljsfxKV1FpU8Tf1A7ZpGvyd/Q4hlrJm2EwoH2onaUq3O4tLDp+4gk0hHPsMyxmOg=="
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
+            "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ=="
         },
         "@babel/template": {
             "version": "7.1.2",
@@ -76,25 +76,25 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.1.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.5.tgz",
-            "integrity": "sha512-eU6XokWypl0MVJo+MTSPUtlfPePkrqsF26O+l1qFGlCKWwmiYAYy2Sy44Qw8m2u/LbPCsxYt90rghmqhYMGpPA==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
+            "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.1.5",
+                "@babel/generator": "^7.1.6",
                 "@babel/helper-function-name": "^7.1.0",
                 "@babel/helper-split-export-declaration": "^7.0.0",
-                "@babel/parser": "^7.1.5",
-                "@babel/types": "^7.1.5",
-                "debug": "^3.1.0",
+                "@babel/parser": "^7.1.6",
+                "@babel/types": "^7.1.6",
+                "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.10"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+                    "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
                     "requires": {
                         "ms": "^2.1.1"
                     }
@@ -107,9 +107,9 @@
             }
         },
         "@babel/types": {
-            "version": "7.1.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.5.tgz",
-            "integrity": "sha512-sJeqa/d9eM/bax8Ivg+fXF7FpN3E/ZmTrWbkk6r+g7biVYfALMnLin4dKijsaqEhpd2xvOGfQTkQkD31YCVV4A==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
+            "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
             "requires": {
                 "esutils": "^2.0.2",
                 "lodash": "^4.17.10",
@@ -121,7 +121,7 @@
             "resolved": "http://npm.tribalnova.com/@hmh%2fnodejs-base-server/-/nodejs-base-server-2.1.9.tgz",
             "integrity": "sha512-iSGf6T3nTLiVlU3usjyDiK9gowUy+/C2k7RMnWi1BHebcm797c9sn1cSMch1QfJk3DIcLSEE76ClqOctAeAX8A==",
             "requires": {
-                "aws-sdk": "^2.353.0",
+                "aws-sdk": "^2.362.0",
                 "body-parser": "^1.18.3",
                 "commander": "^2.18.0",
                 "compression": "^1.7.3",
@@ -130,7 +130,7 @@
                 "express": "^4.16.4",
                 "globby": "^8.0.1",
                 "morgan": "^1.9.1",
-                "node-fetch": "^2.2.1",
+                "node-fetch": "^2.3.0",
                 "reflect-metadata": "^0.1.12"
             }
         },
@@ -197,14 +197,14 @@
             "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww=="
         },
         "@types/node": {
-            "version": "10.12.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.5.tgz",
-            "integrity": "sha512-GzdHjq3t3eGLMv92Al90Iq+EoLL+86mPfQhuglbBFO7HiLdC/rkt+zrzJJumAiBF6nsrBWhou22rPW663AAyFw=="
+            "version": "10.12.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.10.tgz",
+            "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w=="
         },
         "@types/prettier": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.13.2.tgz",
-            "integrity": "sha512-k6MCN8WuDiCj6O+UJsVMbrreZxkbrhQbO02oDj6yuRu8UAkp0MDdEcDKif8/gBKuJbT84kkO+VHQAqXkumEklg==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.15.1.tgz",
+            "integrity": "sha512-e8gYOt6EQQXlpoUGn3KDU9I9/ao/Layl92WgcPRxYYLw2TsuVkRGu5D/5viVPl1IL3nd/4oXw7bL/3MRh2MM1g==",
             "dev": true
         },
         "abbrev": {
@@ -227,9 +227,9 @@
             "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
         },
         "acorn-jsx": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
-            "integrity": "sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg=="
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+            "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
         },
         "agent-base": {
             "version": "4.2.1",
@@ -383,9 +383,9 @@
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
         "aws-sdk": {
-            "version": "2.353.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.353.0.tgz",
-            "integrity": "sha512-c5MwJhfcHwA2lC1Wq9csQvP9gz8dVGpZ64s5j9f/sWY6eZiDCQ6OWjxj+VJfpnCmfxyC/pdZO7JDGwems7dqIQ==",
+            "version": "2.362.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.362.0.tgz",
+            "integrity": "sha512-EZOFs2XjJ9Zj1maDnVHEk2cXV1DFwPRUVEua0oA+oSRYhJ/8Arxm7S+6SRmoYki2V03ff8r1/CfxvA8acFkVrQ==",
             "requires": {
                 "buffer": "4.9.1",
                 "events": "1.1.1",
@@ -718,16 +718,16 @@
             }
         },
         "concurrently": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.0.1.tgz",
-            "integrity": "sha512-D8UI+mlI/bfvrA57SeKOht6sEpb01dKk+8Yee4fbnkk1Ue8r3S+JXoEdFZIpzQlXJGtnxo47Wvvg/kG4ba3U6Q==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.1.0.tgz",
+            "integrity": "sha512-pwzXCE7qtOB346LyO9eFWpkFJVO3JQZ/qU/feGeaAHiX1M3Rw3zgXKc5cZ8vSH5DGygkjzLFDzA/pwoQDkRNGg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.1",
                 "date-fns": "^1.23.0",
                 "lodash": "^4.17.10",
                 "read-pkg": "^4.0.1",
-                "rxjs": "6.2.2",
+                "rxjs": "^6.3.3",
                 "spawn-command": "^0.0.2-1",
                 "supports-color": "^4.5.0",
                 "tree-kill": "^1.1.0",
@@ -818,13 +818,10 @@
             }
         },
         "decamelize": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-            "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-            "dev": true,
-            "requires": {
-                "xregexp": "4.0.0"
-            }
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
         },
         "decode-uri-component": {
             "version": "0.2.0",
@@ -974,7 +971,7 @@
                 },
                 "source-map": {
                     "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                     "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
                     "optional": true,
                     "requires": {
@@ -1383,7 +1380,7 @@
         },
         "globby": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
             "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
             "requires": {
                 "array-union": "^1.0.1",
@@ -1937,9 +1934,9 @@
             }
         },
         "map-age-cleaner": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
-            "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
             "dev": true,
             "requires": {
                 "p-defer": "^1.0.0"
@@ -2196,9 +2193,9 @@
             "dev": true
         },
         "node-fetch": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.1.tgz",
-            "integrity": "sha512-ObXBpNCD3A/vYQiQtEWl7DuqjAXjfptYFuGHLdPl5U19/6kJuZV+8uMHLrkj3wJrJoyfg4nhgyFixZdaZoAiEQ=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+            "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
         },
         "nopt": {
             "version": "3.0.6",
@@ -2703,9 +2700,9 @@
             }
         },
         "rxjs": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
-            "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
+            "version": "6.3.3",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+            "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -3457,12 +3454,6 @@
             "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
             "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         },
-        "xregexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-            "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
-            "dev": true
-        },
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -3475,13 +3466,13 @@
             "dev": true
         },
         "yargs": {
-            "version": "12.0.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
-            "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+            "version": "12.0.5",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+            "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
             "dev": true,
             "requires": {
                 "cliui": "^4.0.0",
-                "decamelize": "^2.0.0",
+                "decamelize": "^1.2.0",
                 "find-up": "^3.0.0",
                 "get-caller-file": "^1.0.1",
                 "os-locale": "^3.0.0",
@@ -3491,24 +3482,17 @@
                 "string-width": "^2.0.0",
                 "which-module": "^2.0.0",
                 "y18n": "^3.2.1 || ^4.0.0",
-                "yargs-parser": "^10.1.0"
+                "yargs-parser": "^11.1.1"
             }
         },
         "yargs-parser": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-            "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+            "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
             "dev": true,
             "requires": {
-                "camelcase": "^4.1.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-                    "dev": true
-                }
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
             }
         },
         "yauzl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@hmh/lit-element-tester",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "source-map-support": "latest"
     },
     "devDependencies": {
-        "@polymer/lit-element": "^0.6.2",
+        "@polymer/lit-element": "^0.6.3",
         "@types/prettier": "latest",
         "concurrently": "latest",
         "typescript": "latest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hmh/lit-element-tester",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "Framework to unit test custom elements on Chrome",
     "bin": {
         "lit-element-tester": "dist/lib/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hmh/lit-element-tester",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Framework to unit test custom elements on Chrome",
     "bin": {
         "lit-element-tester": "dist/lib/cli.js"

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -50,9 +50,9 @@ if (process.env.CHROME_EXECUTABLE_PATH) {
 
     // Run the tests
     if (program.development) {
-        await startServer(configFile, program.port);
+        await startServer(configFile, true, program.port);
     } else {
-        await startServer(configFile, program.port);
+        await startServer(configFile, false, program.port);
         await run(options);
         stopServer();
     }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -23,11 +23,13 @@ function instrumentFile(sourceFile: string) {
  *
  * @param files : a list of javascript files to instrument with Istanbul
  */
-export function instrument(files: string[] = []) {
+export function instrument(files: string[] = [], persistent: boolean = false) {
     for (const sourceFile of files) {
         if (!sourceFile.endsWith('.$.js')) {
             instrumentFile(sourceFile);
-            watch(sourceFile, () => instrumentFile(sourceFile));
+            if (persistent) {
+                watch(sourceFile, () => instrumentFile(sourceFile));
+            }
         }
     }
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,27 +3,31 @@ import { loadCoverage, remap, writeReport } from 'remap-istanbul';
 import { createReporter } from 'istanbul-api';
 import { createCoverageMap } from 'istanbul-lib-coverage';
 import { createInstrumenter } from 'istanbul-lib-instrument';
-import { readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { readFileSync, writeFileSync, unlinkSync, watch } from 'fs';
 import { format } from 'prettier';
+
+const instrumenter: any = createInstrumenter({ esModules: true, produceSourceMap: true });
+
+function instrumentFile(sourceFile: string) {
+    const instrumentedFile = sourceFile.replace('.js', '.$.js');
+
+    const code: string = readFileSync(sourceFile, 'utf8');
+
+    const instrumentedCode: string = instrumenter.instrumentSync(code, sourceFile);
+    writeFileSync(instrumentedFile, format(instrumentedCode, { singleQuote: true, parser: 'babylon', tabWidth: 4 }), 'utf8');
+    console.log('intrumenting:', sourceFile);
+}
 
 /**
  * Instrument Javascript files for code coverage reporting
  *
  * @param files : a list of javascript files to instrument with Istanbul
  */
-export async function instrument(files: string[] = []) {
-    const instrumenter: any = createInstrumenter({ esModules: true, produceSourceMap: true });
-
+export function instrument(files: string[] = []) {
     for (const sourceFile of files) {
         if (!sourceFile.endsWith('.$.js')) {
-            const instrumentedFile = sourceFile.replace('.js', '.$.js');
-
-            const code: string = readFileSync(sourceFile, 'utf8');
-
-            const instrumentedCode: string = instrumenter.instrumentSync(code, sourceFile);
-            writeFileSync(instrumentedFile, format(instrumentedCode, { singleQuote: true, parser: 'babylon', tabWidth: 4 }), 'utf8');
-            console.log('intrumenting:', sourceFile);
-
+            instrumentFile(sourceFile);
+            watch(sourceFile, () => instrumentFile(sourceFile));
         }
     }
 }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -8,10 +8,10 @@ import { instrument } from './index';
 class Server extends Parent {
     private instrumentedFiles: string[];
 
-    public async configureAndStart(config: { [key: string]: any }, configMode?: string, port?: string): Promise<void> {
+    public async configureAndStart(config: { [key: string]: any }, configMode?: string, port?: string, persistent: boolean = false): Promise<void> {
         this.instrumentedFiles = sync(config[configMode].LitElementTester.instrumentedFiles);
         if (this.instrumentedFiles) {
-            await instrument(this.instrumentedFiles);
+            instrument(this.instrumentedFiles, persistent);
         }
         // Generate import map
         const generator: ImportMapGenerator = new ImportMapGenerator(config[configMode]);
@@ -57,7 +57,7 @@ class Server extends Parent {
 
 const instance: Server = new Server();
 
-export async function startServer(config: string, port: string, mode: string = 'dev') {
+export async function startServer(config: string, persistent: boolean, port: string, mode: string = 'dev') {
     assert(config, 'You must provide a server configuration file, see src/server/config.json for an example.');
     assert(existsSync(config), `The configuration file does not exist: ${config}`);
 
@@ -70,7 +70,7 @@ export async function startServer(config: string, port: string, mode: string = '
     console.log('Server root directory:', process.cwd());
     appConfig[mode].NodeServer.defaultClientContentPath = appConfig[mode].LitElementTester.testClientContentPath;
     appConfig[mode].NodeServer.disableLogging = appConfig[mode].LitElementTester.disableLogging ? true : false;
-    await instance.configureAndStart(appConfig, mode, port);
+    await instance.configureAndStart(appConfig, mode, port, persistent);
 }
 
 export function stopServer() {


### PR DESCRIPTION
This PR fixes a painpoint when developing unit tests in dev mode.
Because files were instrumented, and instrumentation only happened when starting the server, 
one had to manually restart the server for any change in the source code to take effect.

I am using the bult-in fs watcher to watch for file changes, and reinstrument to changed files.